### PR TITLE
Migrate custom tables to use YID instead of UUIDs

### DIFF
--- a/.active_record_doctor
+++ b/.active_record_doctor
@@ -25,23 +25,26 @@ ActiveRecordDoctor.configure do
   detector :incorrect_length_validation, ignore_attributes: [
     # app only validation sufficient, no need to enforce length in DB
     "Picture.name",
+    "Picture.yid",
     "Team.name",
+    "Team.yid",
     "User.email",
     "User.name",
     "User.nickname",
     "User.password_digest",
+    "User.yid",
 
     "User.temp_auth_token", # for some reason DB Doctor complains about a (non) existing validation on this column?!
   ]
 
-  detector :missing_presence_validation, ignore_attributes: [
-    "Member.roles",
-    "Team.preferences",
-    "User.preferences",
+  detector :short_primary_key_type, ignore_tables: [
+    "members",
+    "pictures",
+    "teams",
+    "users",
   ]
 
-  detector :unindexed_foreign_keys, ignore_columns: [
-    "members.team_id",
-    "members.user_id",
+  detector :undefined_table_references, ignore_models: [
+    "ApplicationRecordYidEnabled",
   ]
 end

--- a/README.md
+++ b/README.md
@@ -9,26 +9,26 @@ YID are **sortable** **unique** IDs which contain:
 
 * the object klass (unique nickname)
 * the created_at timestamp at UTC in ISO8601 form with microsecond precision
-* a UUID in a url_safe form
+* a short UUID in a url safe form
 
 YID are:
 
-* stored in the database field `yid` 
+* stored in the database field `yid` as primary key
 * used in serializers to the frontend
 * used in associations to other objects (with DB foreign_key)
-* primary_keys to be compatible with Rails' associations
-* ideally be created on Postgres level
+* used as foreign_keys in Rails associations
+* ideally be created on Postgres level (currently not done)
 * for now created by in a Rails hook before persisting a new object
 * stable, they never change
 
 YID are constructed like this:
 
-* `photo_2023-02-26T09:20:20.075800Z_TN1ol4FTGH3MV7utQ3laPQ`
-* `object.klass_object.created_at.utc.iso8601(6)_object.uuid.urlsafe_base64`
-* _Be aware that the "random" UUID part (everything after the 2nd `_`) can contain **any** character._
+* `photo_2023-02-26T09:20:20.075800Z_6511ee876a86`
+* `object.klass::YID_MODEL_object.created_at.utc.iso8601(6)_SecureRandom.hex(6)`
+* _Be aware that the "random" UUID part (everything after the 2nd `_`) is rather short and like this not good enough to be used as standalone UUID._
 
 > YID creation is slow compared to integer IDs or UUIDs, they are long and comparing them is more costly than comparing UUIDs. Their benefits are that they directly reveal the type of object (which is a massive bonus when debugging or sharing object identifiers) and that they are sortable at every moment, without additional database queries (which can speed up the app a lot).
 
 Any YID can be fed to the search / an endpoint / a disolver service which will return the actual object (or an error e.g. 403, 404, ...).
 
-YID are used in URLs, but as they are long and probably funny-looking, whenever possible a slug should be used. The slug:
+YID are used in URLs, but as they are long and probably funny-looking, you might consider using slugs. The slug should be created by some fast symmetric encoding / decoding encryption algorithm that backends and frontends can use.

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -55,6 +55,6 @@ class MembersController < ApplicationController
   # TODO: roles handling broken / move to extra endpoint - or add specific logic to create and update
   # Only allow a list of trusted parameters through. // TODO: dry-validation / dry-contract ?!
   def member_params
-    params.require(:member).permit(:user_id, :team_id, :roles)
+    params.require(:member).permit(:user_yid, :team_yid, :roles)
   end
 end

--- a/app/models/application_record_yid_enabled.rb
+++ b/app/models/application_record_yid_enabled.rb
@@ -1,0 +1,30 @@
+class ApplicationRecordYidEnabled < ApplicationRecord
+  self.abstract_class = true
+  self.primary_key = "yid"
+
+  before_create :set_yid_and_timestamps
+
+  private
+
+  def decode_from_slug(slug)
+    # use OpenSSL::Cipher::AES128 or similar to decode to yid
+  end
+
+  def encode_to_slug
+    # use OpenSSL::Cipher::AES128 or similar to encode yid
+  end
+
+  def generate_yid
+    "#{self.class::YID_MODEL}_#{now_timestamp}_#{SecureRandom.hex(6)}"
+  end
+
+  def now_timestamp
+    @now_timestamp ||= Time.current.utc.iso8601(6)
+  end
+
+  def set_yid_and_timestamps
+    self.created_at = now_timestamp
+    self.updated_at = now_timestamp
+    self.yid = generate_yid
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -4,7 +4,7 @@
 # A Team can only be destroyed if last owner decides to destroy the Team
 #  while still being part of another team or if the last owner decides to destroy their whole Account.
 
-class Member < ApplicationRecord
+class Member < ApplicationRecordYidEnabled
   VALID_ROLES = [
     "owner", # owns the team, can invite/remove other users to/from the team, can manage everything team related
     "manager", # can manage all team related objects, change member roles (except owner) and invite readers
@@ -14,17 +14,21 @@ class Member < ApplicationRecord
     # "creator", # can create memories with note, photo and location, but not update or delete those or any else
     # "reader", # can read all team wide published objects, but not create or update any
   ].freeze
+  YID_MODEL = "member".freeze
 
-  belongs_to :team, inverse_of: :members
-  belongs_to :user, inverse_of: :memberships
+  belongs_to :team, inverse_of: :members, foreign_key: "team_yid"
+  belongs_to :user, inverse_of: :memberships, foreign_key: "user_yid"
 
-  validates :team_id, presence: true, uniqueness: { scope: :user_id }
-  validates :user_id, presence: true, uniqueness: { scope: :team_id }
+  validates :team_yid, presence: true, uniqueness: { scope: :user_yid }
+  validates :user_yid, presence: true, uniqueness: { scope: :team_yid }
+  validates :roles, presence: true, if: proc { |record| record.roles.to_s == "" }
   validates :roles, array_inclusion: {
     in: VALID_ROLES, message: "%{rejected_values} not allowed, roles must be in #{VALID_ROLES}"
   } # this uses the custom ArrayInclusionValidator
 
   after_initialize :define_has_role_methods
+
+  delegate :name, :nickname, to: :user
 
   def add_role!(role)
     add_role(role).save!

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -5,11 +5,12 @@
 # if deleting the original should not be possible, we should prevent uploading 10 MB files
 # and introduce a smaller limit - at least for non-paying users
 
-class Picture < ApplicationRecord
+class Picture < ApplicationRecordYidEnabled
   has_one_attached :file
 
   ALLOWED_IMAGE_TYPES = %w[gif jpg jpeg png tiff webp].freeze
   ALLOWED_CONTENT_TYPES = ALLOWED_IMAGE_TYPES.map { |type| "image/#{type}" }.freeze
+  YID_MODEL = "pic".freeze
 
   # NOTE
   # In PicturesController#create the uploaded files are resized (downsized) to to max of 4000x3000

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,9 @@
-class Team < ApplicationRecord
-  has_many :members, class_name: "Member", inverse_of: :team, dependent: :destroy
+class Team < ApplicationRecordYidEnabled
+  YID_MODEL = "team".freeze
+
+  has_many :members, class_name: "Member", foreign_key: "team_yid", inverse_of: :team, dependent: :destroy
   has_many :users, through: :members
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 72 }
+  validates :preferences, presence: true, if: proc { |record| record.preferences.to_s == "" }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,10 @@
-class User < ApplicationRecord
+class User < ApplicationRecordYidEnabled
   SEPARATOR = "::".freeze
+  YID_MODEL = "user".freeze
 
   has_secure_password :password, validations: false
 
-  has_many :memberships, class_name: "Member", inverse_of: :user, dependent: :destroy
+  has_many :memberships, class_name: "Member", foreign_key: "user_yid", inverse_of: :user, dependent: :destroy
   has_many :teams, through: :memberships
 
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP, message: "not valid" }
@@ -11,6 +12,7 @@ class User < ApplicationRecord
   validates :password_digest, presence: true
   validates :name, presence: true, length: { in: 3..72 }
   validates :nickname, allow_nil: true, uniqueness: true, length: { in: 3..72 }
+  validates :preferences, presence: true, if: proc { |record| record.preferences.to_s == "" }
 
   class << self
     def authenticate_temp_auth_token!(base64)

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -6,13 +6,13 @@
       <h3><legend><%= form_legend %></legend></h3>
 
       <div>
-        <%= form.label :user_id %>
-        <%= form.text_field :user_id %>
+        <%= form.label :user_yid %>
+        <%= form.text_field :user_yid %>
       </div>
 
       <div>
-        <%= form.label :team_id %>
-        <%= form.text_field :team_id %>
+        <%= form.label :team_yid %>
+        <%= form.text_field :team_yid %>
       </div>
 
       <div>

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -1,12 +1,12 @@
 <article id="<%= dom_id member %>">
   <p>
     <strong>User:</strong>
-    <%= member.user_id %>
+    <%= member.user_yid %>
   </p>
 
   <p>
     <strong>Team:</strong>
-    <%= member.team_id %>
+    <%= member.team_yid %>
   </p>
 
   <p>

--- a/db/migrate/20230725150420_add_yid_to_all_tables.rb
+++ b/db/migrate/20230725150420_add_yid_to_all_tables.rb
@@ -1,0 +1,76 @@
+#
+# Destructive Migration - only to be run on empty databases!
+#
+class AddYidToAllTables < ActiveRecord::Migration[7.0]
+  def up
+    remove_foreign_key :members, :teams, column: :team_id, primary_key: "id"
+    remove_foreign_key :members, :users, column: :user_id, primary_key: "id"
+    remove_column :members, :team_id, :uuid, null: false
+    remove_column :members, :user_id, :uuid, null: false
+
+    execute "ALTER TABLE members DROP CONSTRAINT members_pkey" # remove the PRIMARY KEY id
+    remove_column :members, :id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    add_column :members, :yid, :string, primary_key: true, null: false
+    # add_index :members, :yid, unique: true
+
+    execute "ALTER TABLE pictures DROP CONSTRAINT pictures_pkey" # remove the PRIMARY KEY id
+    remove_column :pictures, :id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    add_column :pictures, :yid, :string, primary_key: true, null: false
+    # add_index :pictures, :yid, unique: true
+
+    execute "ALTER TABLE teams DROP CONSTRAINT teams_pkey" # remove the PRIMARY KEY id
+    remove_column :teams, :id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    add_column :teams, :yid, :string, primary_key: true, null: false
+    # add_index :teams, :yid, unique: true
+
+    execute "ALTER TABLE users DROP CONSTRAINT users_pkey" # remove the PRIMARY KEY id
+    remove_column :users, :id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    add_column :users, :yid, :string, primary_key: true, null: false
+    # add_index :users, :yid, unique: true
+
+    change_column :active_storage_attachments, :record_id, :string
+
+    add_column :members, :team_yid, :string, null: false
+    add_column :members, :user_yid, :string, null: false
+    add_foreign_key :members, :teams, column: :team_yid, primary_key: "yid"
+    add_foreign_key :members, :users, column: :user_yid, primary_key: "yid"
+    add_index :members, %i[team_yid user_yid], unique: true
+    add_index :members, :user_yid
+  end
+
+  def down
+    remove_index :members, :user_yid
+    remove_index :members, %i[team_yid user_yid], unique: true
+    remove_foreign_key :members, :teams, column: :team_yid, primary_key: "yid"
+    remove_foreign_key :members, :users, column: :user_yid, primary_key: "yid"
+    remove_column :members, :team_yid, :string, null: false
+    remove_column :members, :user_yid, :string, null: false
+
+    execute "ALTER TABLE members DROP CONSTRAINT members_pkey" # remove the PRIMARY KEY yid
+    remove_column :members, :yid, :string, null: false
+    add_column :members, :id, :uuid, primary_key: true, null: false, default: -> { "gen_random_uuid()" }
+    # add_index :members, :id, unique: true
+
+    execute "ALTER TABLE pictures DROP CONSTRAINT pictures_pkey" # remove the PRIMARY KEY yid
+    remove_column :pictures, :yid, :string, null: false
+    add_column :pictures, :id, :uuid, primary_key: true, null: false, default: -> { "gen_random_uuid()" }
+    # add_index :pictures, :id, unique: true
+
+    execute "ALTER TABLE teams DROP CONSTRAINT teams_pkey" # remove the PRIMARY KEY yid
+    remove_column :teams, :yid, :string, null: false
+    add_column :teams, :id, :uuid, primary_key: true, null: false, default: -> { "gen_random_uuid()" }
+    # add_index :teams, :id, unique: true
+
+    execute "ALTER TABLE users DROP CONSTRAINT users_pkey" # remove the PRIMARY KEY yid
+    remove_column :users, :yid, :string, null: false
+    add_column :users, :id, :uuid, primary_key: true, null: false, default: -> { "gen_random_uuid()" }
+    # add_index :users, :id, unique: true
+
+    change_column :active_storage_attachments, :record_id, :uuid, using: "record_id::uuid"
+
+    add_column :members, :team_id, :uuid, null: false
+    add_column :members, :user_id, :uuid, null: false
+    add_foreign_key :members, :teams, column: :team_id, primary_key: "id"
+    add_foreign_key :members, :users, column: :user_id, primary_key: "id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_27_155442) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_25_150420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_27_155442) do
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.uuid "record_id", null: false
+    t.string "record_id", null: false
     t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
@@ -43,22 +43,23 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_27_155442) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "members", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.uuid "team_id", null: false
+  create_table "members", primary_key: "yid", id: :string, force: :cascade do |t|
     t.text "roles", default: [], null: false, array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["team_id", "user_id"], name: "index_members_on_team_id_and_user_id", unique: true
+    t.string "team_yid", null: false
+    t.string "user_yid", null: false
+    t.index ["team_yid", "user_yid"], name: "index_members_on_team_yid_and_user_yid", unique: true
+    t.index ["user_yid"], name: "index_members_on_user_yid"
   end
 
-  create_table "pictures", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "pictures", primary_key: "yid", id: :string, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "teams", primary_key: "yid", id: :string, force: :cascade do |t|
     t.string "name", null: false
     t.jsonb "preferences", default: {}, null: false
     t.datetime "created_at", null: false
@@ -66,7 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_27_155442) do
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users", primary_key: "yid", id: :string, force: :cascade do |t|
     t.string "name", null: false
     t.string "nickname"
     t.string "email", null: false
@@ -82,6 +83,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_27_155442) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "members", "teams"
-  add_foreign_key "members", "users"
+  add_foreign_key "members", "teams", column: "team_yid", primary_key: "yid"
+  add_foreign_key "members", "users", column: "user_yid", primary_key: "yid"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,18 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# TODO: clear DB before populating it
+
+andy = User.create!(email: "andy@example.com", password: "foobar1234", name: "Andy")
+dodo = User.create!(email: "dodo@example.com", password: "foobar1234", name: "Dodo")
+user = User.create!(email: "user@example.com", password: "foobar1234", name: "User")
+
+rtv = Team.create!(name: "RanTanVan")
+team = Team.create!(name: "team")
+
+rtv_owner = Member.create!(user: andy, team: rtv, roles: %w[owner publisher])
+rtv_editor = Member.create!(user: dodo, team: rtv, roles: %w[manager editor])
+
+# TODO: create picture
+# TODO: create weblink
+# TODO: create geo-location
+# TODO: create memory
+# TODO: create chronicle
+# TODO: create experience

--- a/spec/views/members/edit.html.erb_spec.rb
+++ b/spec/views/members/edit.html.erb_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "members/edit", type: :view do
     render
 
     assert_select "form[action=?][method=?]", member_path(member), "post" do
-      assert_select "input[name=?]", "member[user_id]"
-      assert_select "input[name=?]", "member[team_id]"
+      assert_select "input[name=?]", "member[user_yid]"
+      assert_select "input[name=?]", "member[team_yid]"
       assert_select "textarea[name=?]", "member[roles]"
     end
   end

--- a/spec/views/members/new.html.erb_spec.rb
+++ b/spec/views/members/new.html.erb_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "members/new", type: :view do
   it "renders new member form" do
     render
     assert_select "form[action=?][method=?]", members_path, "post" do
-      assert_select "input[name=?]", "member[user_id]"
-      assert_select "input[name=?]", "member[team_id]"
+      assert_select "input[name=?]", "member[user_yid]"
+      assert_select "input[name=?]", "member[team_yid]"
       assert_select "textarea[name=?]", "member[roles]"
     end
   end

--- a/spec/views/members/show.html.erb_spec.rb
+++ b/spec/views/members/show.html.erb_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "members/show", type: :view do
 
   it "renders attributes in <p>" do
     render
-    expect(rendered).to match(/#{member.user_id}/)
-    expect(rendered).to match(/#{member.team_id}/)
+    expect(rendered).to match(/#{member.user_yid}/)
+    expect(rendered).to match(/#{member.team_yid}/)
     expect(rendered).to match(/#{member.roles}/)
   end
 end


### PR DESCRIPTION
# Idea

Rather large change, to not use UUIDs for our custom tables, but YIDs (Yournaling IDs) that consist of three parts:

* an identifier of the model class _(e.g. "user", "team", "member" or "pic" for pictures)_
* an ISO8601 timestamp _(same as "created_at" with microsecond precision)_
* an UUID _(a short one with only 48bit entropy)_
* separated by `_` underscores

In this implementation the YIDs have to be generated on the server.

## YID - Yournaling ID

YID are **sortable** **unique** IDs which contain:

* the object class (unique nickname)
* the created_at timestamp at UTC in ISO8601 form with microsecond precision
* a short UUID in a url safe form

YID are:

* stored in the database field `yid` as primary key
* used in serializers to the frontend
* used in associations to other objects (with DB foreign_key)
* used as foreign_keys in Rails associations
* ideally be created on Postgres level (currently not done)
* for now created by in a Rails hook before persisting a new object
* stable, they never change

YID are constructed like this:

* `user_2023-02-26T09:20:20.075800Z_6511ee876a86`
* `object.klass::YID_MODEL_object.created_at.utc.iso8601(6)_SecureRandom.hex(6)`
* _Be aware that the "random" UUID part (everything after the 2nd `_`) is rather short and like this not good enough to be used as standalone UUID._

> YID creation is slow compared to integer IDs or UUIDs, they are long and comparing them is more costly than comparing UUIDs. Their benefits are that they directly reveal the type of object (which is a massive bonus when debugging or sharing object identifiers) and that they are sortable at every moment, without additional database queries (which can speed up the app a lot).

Any YID can be fed to the search / an endpoint / a disolver service which can then return the actual object (or an error e.g. 403, 404, ...).

YID can be used in URLs, but as they are long and probably funny-looking, you might consider using slugs. The slug should be created by some fast symmetric encoding / decoding encryption algorithm that backends and frontends can use.
