### PR TITLE
Authenticate current_user and select current_team

### DIFF
--- a/app/assets/stylesheets/buttons.css
+++ b/app/assets/stylesheets/buttons.css
@@ -1,0 +1,7 @@
+.logout {
+  margin-top: 1rem;
+  width: 10rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery prepend: true
 
+  include RequestContext # sets the Current.objects
+
   # Detailed error pages must only be used in development! By default use our custom (less informative) error pages
   include ErrorHandler unless AppConf.is?(:debug, true) && !AppConf.production_env
 
@@ -18,6 +20,16 @@ class ApplicationController < ActionController::Base
     @current_user ||= session[:user_yid] ? User.urlsafe_find(session[:user_yid]) : User.new(name: "Guest")
   end
   helper_method :current_user
+
+  def current_team
+    Current.team
+  end
+  helper_method :current_team
+
+  def current_member
+    Current.member
+  end
+  helper_method :current_member
 
   # dry-validates the dry-contract against the given params
   # which can be either a hash or an ActionController::Parameters object

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,46 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_user
+
+    before_action :authenticate
+  end
+
+  def sign_in(email:, password:)
+    user = User.authenticate_by(email:, password:)
+
+    if user.present?
+      reset_session
+      session[:user_yid] = user.urlsafe_id
+      @current_user = user
+      initialize_request_context # to refresh the Current objects directly
+    end
+
+    current_user
+  end
+
+  def sign_out
+    reset_session
+    @current_user = guest_user
+    initialize_request_context # to refresh the Current objects directly
+    current_user
+  end
+
+  private
+
+  def authenticate(allow_guest: true)
+    return if current_user.present? && (current_user.persisted? || allow_guest)
+
+    session[:return_to] ||= request.referer
+    redirect_to :login
+  end
+
+  def current_user
+    @current_user ||= session[:user_yid] ? User.urlsafe_find(session[:user_yid]) : guest_user
+  end
+
+  def guest_user
+    User.new(name: "Guest")
+  end
+end

--- a/app/controllers/concerns/request_context.rb
+++ b/app/controllers/concerns/request_context.rb
@@ -1,0 +1,38 @@
+module RequestContext
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :initialize_request_context
+    # before_action :set_sentry_context # uncomment when hosting and using Sentry
+  end
+
+  private
+
+  def initialize_request_context
+    Current.user = current_user
+    Current.team = Current.user.teams.find(session[:team_yid]) if session[:team_yid]
+    Current.member = Current.user.memberships.find_by!(team: Current.team) if Current.team
+
+    Current.module_name = self.class.module_parent_name
+    Current.path = request.path
+    Current.request_id = request.request_id # set via middleware gem Rack::RequestID and/or ActionDispatch::RequestId
+  end
+
+  # uncomment when hosting and using Sentry
+  #
+  # def set_sentry_context
+  #   Sentry.set_user(id: Current.user&.yid)
+  #
+  #   Sentry.configure_scope do |scope|
+  #     scope.set_extras(
+  #       request_id: Current.request_id
+  #       params: request.filtered_parameters,
+  #
+  #       user_yid: Current.user&.yid
+  #       team_yid: Current.team&.yid,
+  #       member_yid: Current.member&.yid,
+  #       member_roles: Current.member&.roles,
+  #     )
+  #   end
+  # end
+end

--- a/app/controllers/concerns/request_context.rb
+++ b/app/controllers/concerns/request_context.rb
@@ -10,8 +10,8 @@ module RequestContext
 
   def initialize_request_context
     Current.user = current_user
-    Current.team = Current.user.teams.find(session[:team_yid]) if session[:team_yid]
-    Current.member = Current.user.memberships.find_by!(team: Current.team) if Current.team
+    Current.team = current_team
+    Current.member = current_member
 
     Current.module_name = self.class.module_parent_name
     Current.path = request.path

--- a/app/controllers/concerns/team_scope.rb
+++ b/app/controllers/concerns/team_scope.rb
@@ -1,0 +1,39 @@
+module TeamScope
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_team, :current_member
+
+    # before_action :...
+  end
+
+  def switch_current_team(team_yid)
+    team = current_user.teams.find(team_yid)
+
+    session[:team_yid] = team.yid
+    @current_team = team
+    @current_member = current_user.memberships.find_by!(team:)
+    initialize_request_context # to refresh the Current objects directly
+
+    current_team
+  end
+
+  def go_solo
+    session[:team_yid] = nil
+    @current_team = nil
+    @current_member = nil
+    initialize_request_context # to refresh the Current objects directly
+
+    true
+  end
+
+  private
+
+  def current_team
+    @current_team ||= current_user.teams.find(session[:team_yid]) if session[:team_yid]
+  end
+
+  def current_member
+    @current_member ||= current_user.memberships.find_by!(team: current_team) if current_team
+  end
+end

--- a/app/controllers/current_teams_controller.rb
+++ b/app/controllers/current_teams_controller.rb
@@ -1,0 +1,34 @@
+class CurrentTeamsController < ApplicationController
+  # GET /user/teams
+  def index
+    @current_teams = current_user.teams
+
+    render template: "current_teams/index"
+  end
+
+  def show
+    @current_team = current_team # == Current.team # == current_user.teams.find_by(yid: session[:team_yid])
+
+    if @current_team
+      render partial: "teams/team", locals: { team: @current_team }
+    else
+      redirect_to current_teams_url, notice: "No Team selected"
+    end
+  end
+
+  # POST /user/teams
+  def create
+    @team = current_user.teams.find_by!(yid: current_team_params[:team_yid])
+
+    session[:team_yid] = @team.yid
+    initialize_request_context # to refresh the Current objects directly
+
+    redirect_to @team, notice: "Team #{@team.name} selected"
+  end
+
+  private
+
+  def current_team_params
+    params.require(:current_team).permit(:team_yid)
+  end
+end

--- a/app/controllers/current_teams_controller.rb
+++ b/app/controllers/current_teams_controller.rb
@@ -18,12 +18,16 @@ class CurrentTeamsController < ApplicationController
 
   # POST /user/teams
   def create
-    @team = current_user.teams.find_by!(yid: current_team_params[:team_yid])
-
-    session[:team_yid] = @team.yid
-    initialize_request_context # to refresh the Current objects directly
+    @team = switch_current_team(current_team_params[:team_yid])
 
     redirect_to @team, notice: "Team #{@team.name} selected"
+  end
+
+  # DELETE /user/teams
+  def destroy
+    go_solo
+
+    redirect_to root_path, notice: "No Team selected, going solo"
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,8 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate, only: %i[home error]
+
   def home
+    redirect_to pictures_path
   end
 
   def error

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -1,4 +1,5 @@
 class PicturesController < ApplicationController
+  skip_before_action :authenticate, only: %i[index show] # allow everyone to see the pictures
   before_action :set_picture, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,30 @@
+class SessionsController < ApplicationController
+  skip_before_action :authenticate, only: %i[new create]
+
+  def new
+    render :new
+  end
+
+  def create
+    user = User.authenticate_by(email: login_params[:email], password: login_params[:password])
+
+    if user.present?
+      session[:user_id] = user.urlsafe_id
+      redirect_to session.delete(:return_to) || root_path, notice: "Login successful" # TODO: notice shown, but pointless
+    else
+      render :new, status: :forbidden, notice: "Login failed, please try again" # TODO: notice not shown
+    end
+  end
+
+  def destroy
+    session.clear
+
+    redirect_to root_path
+  end
+
+  private
+
+  def login_params
+    params.permit(:email, :password)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     user = User.authenticate_by(email: login_params[:email], password: login_params[:password])
 
     if user.present?
-      session[:user_id] = user.urlsafe_id
+      session[:user_yid] = user.urlsafe_id
       redirect_to session.delete(:return_to) || root_path, notice: "Login successful" # TODO: notice shown, but pointless
     else
       render :new, status: :forbidden, notice: "Login failed, please try again" # TODO: notice not shown

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,15 +1,14 @@
 class SessionsController < ApplicationController
-  skip_before_action :authenticate, only: %i[new create]
+  skip_before_action :authenticate, only: %i[new create destroy] # allowing destroy means no harm
 
   def new
     render :new
   end
 
   def create
-    user = User.authenticate_by(email: login_params[:email], password: login_params[:password])
+    user = sign_in(email: login_params[:email], password: login_params[:password])
 
     if user.present?
-      session[:user_yid] = user.urlsafe_id
       redirect_to session.delete(:return_to) || root_path, notice: "Login successful" # TODO: notice shown, but pointless
     else
       render :new, status: :forbidden, notice: "Login failed, please try again" # TODO: notice not shown
@@ -17,7 +16,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    session.clear
+    sign_out
 
     redirect_to root_path
   end

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -1,2 +1,0 @@
-module TeamsHelper
-end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,13 @@
+# Store a few per-request attributes here (globally), instead of passing them around everywhere
+#
+# https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+  attribute :team
+  attribute :member
+
+  attribute :module_name
+  attribute :path
+  attribute :request_id
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecordYidEnabled
   validates :preferences, presence: true, if: proc { |record| record.preferences.to_s == "" }
 
   class << self
+    # TODO: refactor to use Rails 7.1 generates_token_for ?!
+    #
     def authenticate_temp_auth_token!(base64)
       expires_at, token = Base64.urlsafe_decode64(base64.to_s).split(SEPARATOR)
       raise StandardError.new("Token invalid, please restart your operation") if expires_at.nil? || token.nil?

--- a/app/views/current_teams/_current_team.html.erb
+++ b/app/views/current_teams/_current_team.html.erb
@@ -10,8 +10,9 @@
   </p>
 
   <% if current_team == Current.team %>
-    <i>"Currently selected team"</i>
+    <%= button_to "go solo", { controller: :current_teams, action: :destroy, id: current_team.urlsafe_id }, method: :delete, class: "secondary", id: current_team.urlsafe_id %>
+    &nbsp; <i>(unlink currently selected team)</i>
   <% else %>
-    <%= button_to "Select this team", current_teams_url({ current_team: { team_yid: current_team.yid} }), method: :post, class: "secondary" %>
+    <%= button_to "Select this team", current_teams_url({ current_team: { team_yid: current_team.yid} }), method: :post, class: "secondary", id: current_team.urlsafe_id %>
   <% end %>
 </article>

--- a/app/views/current_teams/_current_team.html.erb
+++ b/app/views/current_teams/_current_team.html.erb
@@ -1,0 +1,17 @@
+<article id="<%= dom_id current_team %>">
+  <p>
+    <strong>Name:</strong>
+    <%= current_team.name %>
+  </p>
+
+  <p>
+    <strong>Roles:</strong>
+    <%= current_team.members.find_by(user: current_user).roles %>
+  </p>
+
+  <% if current_team == Current.team %>
+    <i>"Currently selected team"</i>
+  <% else %>
+    <%= button_to "Select this team", current_teams_url({ current_team: { team_yid: current_team.yid} }), method: :post, class: "secondary" %>
+  <% end %>
+</article>

--- a/app/views/current_teams/index.html.erb
+++ b/app/views/current_teams/index.html.erb
@@ -1,0 +1,5 @@
+<div id="current_teams">
+  <% @current_teams.each do |current_team| %>
+    <%= render partial: "current_teams/current_team", locals: { current_team: current_team } %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,14 @@
           <li><%= link_to "Members", members_path, role: active_path?(members_path) ? "button" : nil %></li>
         </ul>
 
+        <% if current_user %>
+        <ul>
+          <li>
+            <%= button_to "Logout #{current_user.name}", { controller: :sessions, action: :destroy }, { method: :delete, role: "link", class: "logout" } %>
+          </li>
+        </ul>
+        <% end %>
+
         <ul>
           <li>
           <% if active_path?(pictures_path) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,25 +22,31 @@
           <li><%= link_to "Members", members_path, role: active_path?(members_path) ? "button" : nil %></li>
         </ul>
 
-        <% if current_user %>
         <ul>
-          <li><%= link_to "Switch team", current_teams_path, role: active_path?(current_teams_path) ? "button" : nil %></li>
-          <li>
-            <%= button_to "Logout #{current_user.name}", { controller: :sessions, action: :destroy }, { method: :delete, role: "link", class: "logout" } %>
-          </li>
+          <% if current_user.persisted? %>
+            <% if current_user.teams %>
+              <li><%= link_to "Switch team", current_teams_path %></li>
+            <% end %>
+            <li>
+              <%= button_to "Logout #{current_user.name}", { controller: :sessions, action: :destroy }, { method: :delete, role: "link", class: "logout" } %>
+            </li>
+          <% else %>
+            <li><%= link_to "Login", login_path, role: active_path?(login_path) ? "button" : nil %></li>
+          <% end %>
         </ul>
-        <% end %>
 
         <ul>
           <li>
-          <% if active_path?(pictures_path) %>
-            <%= render partial: "pictures/action_buttons" %>
-          <% elsif active_path?(teams_path) %>
-            <%= render partial: "teams/action_buttons" %>
-          <% elsif active_path?(users_path) %>
-            <%= render partial: "users/action_buttons" %>
-          <% elsif active_path?(members_path) %>
-            <%= render partial: "members/action_buttons" %>
+          <% if current_user.persisted? %>
+            <% if active_path?(pictures_path) %>
+              <%= render partial: "pictures/action_buttons" %>
+            <% elsif active_path?(teams_path) %>
+              <%= render partial: "teams/action_buttons" %>
+            <% elsif active_path?(users_path) %>
+              <%= render partial: "users/action_buttons" %>
+            <% elsif active_path?(members_path) %>
+              <%= render partial: "members/action_buttons" %>
+            <% end %>
           <% end %>
           </li>
         </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
 
         <% if current_user %>
         <ul>
+          <li><%= link_to "Switch team", current_teams_path, role: active_path?(current_teams_path) ? "button" : nil %></li>
           <li>
             <%= button_to "Logout #{current_user.name}", { controller: :sessions, action: :destroy }, { method: :delete, role: "link", class: "logout" } %>
           </li>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,0 +1,23 @@
+<article>
+  <%= form_with url: login_path do |form| %>
+    <%# = render partial: "shared_partials/form_validation_errors", locals: { record: user } %>
+
+    <fieldset>
+      <h3><legend><%= form_legend %></legend></h3>
+
+      <div>
+        <%= form.label :email %>
+        <%= form.text_field :email %>
+      </div>
+
+      <div>
+        <%= form.label :password %>
+        <%= form.password_field :password %>
+      </div>
+
+      <div class="inline">
+        <%= form.submit form_legend %>
+      </div>
+    </fieldset>
+  <% end %>
+</article>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { form_legend: "Login"} %>

--- a/config/app_conf.rb
+++ b/config/app_conf.rb
@@ -120,7 +120,7 @@ class AppConf
   register :log_target, default: production_env ? $stdout : "log/#{environment}.log"
 
   # rack-timeout in seconds
-  register :rack_timeout, default: is?(:debug, true) ? 300 : 60 # seconds
+  register :rack_timeout, default: is?(:debug, true) ? 300 : 10 # seconds
 
   # configure Redis for ActionCable / TurboReflex
   register :redis_url, default: "redis://localhost:6379/1", required: production_env

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
 
   root to: "pages#home"
 
-  get "/pictures_only/:id", to: "pictures_only#show", as: "picture_only"
+  get "login", to: "sessions#new"
+  post "login", to: "sessions#create"
+  delete "logout", to: "sessions#destroy"
+
+  get "/pictures_only/:id", to: "pictures_only#show", as: "picture_only" # TODO: replace :id (YID) with urlsafe_id ?!
 
   # catch all unknown routes to NOT throw a FATAL ActionController::RoutingError
   match "*path", to: "application#error_404", via: :all,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
+  root to: "pages#home"
+
   resources :pictures
   resources :members
   resources :teams
   resources :users
 
-  root to: "pages#home"
+  resources :current_teams, only: %i[index show create]
 
   get "login", to: "sessions#new"
   post "login", to: "sessions#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :teams
   resources :users
 
-  resources :current_teams, only: %i[index show create]
+  resources :current_teams, only: %i[index show create destroy]
 
   get "login", to: "sessions#new"
   post "login", to: "sessions#create"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,8 @@ team = Team.create!(name: "team")
 rtv_owner = Member.create!(user: andy, team: rtv, roles: %w[owner publisher])
 rtv_editor = Member.create!(user: dodo, team: rtv, roles: %w[manager editor])
 
+team_editor = Member.create!(user: andy, team:, roles: %w[editor])
+
 # TODO: create picture
 # TODO: create weblink
 # TODO: create geo-location

--- a/spec/requests/current_teams_request_spec.rb
+++ b/spec/requests/current_teams_request_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe "/current_teams", type: :system do
+  let(:member) { FactoryBot.create(:member) }
+  let(:user) { member.user }
+  let(:team) { member.team }
+
+  before { sign_in(user) }
+
+  describe "GET /index" do
+    it "renders a successful response", aggregate_failures: true do
+      visit current_teams_url
+
+      expect(page).to have_current_path("/current_teams", ignore_query: true)
+      expect(page.status_code).to eq(200) # not supported by selenium driver
+
+      main = page.find("main")
+      expect(main).to have_text(team.name)
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      allow(Current).to receive(:team).and_return(team)
+
+      visit current_team_url(team.urlsafe_id)
+
+      expect(page).to have_current_path("/current_teams/#{team.urlsafe_id}", ignore_query: true)
+      expect(page.status_code).to eq(200) # not supported by selenium driver
+    end
+  end
+
+  describe "POST /create", aggregate_failures: true do
+    context "with valid parameters" do
+      it "selects the Team and redirects to its show page" do
+        login(user)
+
+        expect(Current.team).to be_nil
+
+        post current_teams_path, params: { current_team: { team_yid: team.yid } }
+
+        expect(session[:team_yid]).to eq(team.yid)
+
+        expect(response).to redirect_to(team_path(team))
+      end
+    end
+  end
+end

--- a/spec/requests/current_teams_request_spec.rb
+++ b/spec/requests/current_teams_request_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "/current_teams", type: :system do
   let(:user) { member.user }
   let(:team) { member.team }
 
-  before { sign_in(user) }
+  before { visit_sign_in(user) }
 
   describe "GET /index" do
     it "renders a successful response", aggregate_failures: true do
@@ -19,7 +19,7 @@ RSpec.describe "/current_teams", type: :system do
 
   describe "GET /show" do
     it "renders a successful response" do
-      allow(Current).to receive(:team).and_return(team)
+      visit_switch_current_team(team)
 
       visit current_team_url(team.urlsafe_id)
 
@@ -31,7 +31,7 @@ RSpec.describe "/current_teams", type: :system do
   describe "POST /create", aggregate_failures: true do
     context "with valid parameters" do
       it "selects the Team and redirects to its show page" do
-        login(user)
+        sign_in(user)
 
         expect(Current.team).to be_nil
 
@@ -40,6 +40,22 @@ RSpec.describe "/current_teams", type: :system do
         expect(session[:team_yid]).to eq(team.yid)
 
         expect(response).to redirect_to(team_path(team))
+      end
+    end
+  end
+
+  describe "DELETE /destroy", aggregate_failures: true do
+    context "when a team is selected" do
+      it "removes the current Team selection and redirects to the root_path" do
+        sign_in(user)
+        switch_current_team(team)
+
+        expect(session[:team_yid]).to eq(team.yid)
+
+        go_solo(team)
+
+        expect(session[:team_yid]).to be_nil
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -5,7 +5,7 @@
 #
 # Use Login-Form to login
 #
-def sign_in(user)
+def visit_sign_in(user)
   visit login_url
   fill_in :email, with: user.email
   fill_in :password, with: "foobar1234"
@@ -14,7 +14,7 @@ end
 
 # Click Logout-Button to logout
 #
-def sign_out(user)
+def visit_sign_out(user)
   click_button "Logout #{user.name}"
 end
 
@@ -22,10 +22,10 @@ end
 #
 # RSpec / Rails System spec "get response" methods
 #
-def login(user)
+def sign_in(user)
   post login_path, params: { email: user.email, password: "foobar1234" }
 end
 
-def logout
+def sign_out
   delete logout_path
 end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,5 +1,8 @@
 # Does what Devise::Test::IntegrationHelpers `sign_in(user)` would normally do
 #
+#
+# Capybara "visit page" methods
+#
 # Use Login-Form to login
 #
 def sign_in(user)
@@ -13,4 +16,16 @@ end
 #
 def sign_out(user)
   click_button "Logout #{user.name}"
+end
+
+#
+#
+# RSpec / Rails System spec "get response" methods
+#
+def login(user)
+  post login_path, params: { email: user.email, password: "foobar1234" }
+end
+
+def logout
+  delete logout_path
 end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,0 +1,16 @@
+# Does what Devise::Test::IntegrationHelpers `sign_in(user)` would normally do
+#
+# Use Login-Form to login
+#
+def sign_in(user)
+  visit login_url
+  fill_in :email, with: user.email
+  fill_in :password, with: "foobar1234"
+  click_button "Login"
+end
+
+# Click Logout-Button to logout
+#
+def sign_out(user)
+  click_button "Logout #{user.name}"
+end

--- a/spec/support/team_scope_helper.rb
+++ b/spec/support/team_scope_helper.rb
@@ -1,0 +1,32 @@
+#
+#
+# Capybara "visit page" methods
+#
+def visit_switch_current_team(_team)
+  visit current_teams_url
+
+  page.within("#current_teams") do
+    click_button("Select this team") # should have id: _team.urlsafe_id
+    # find("#{_team.urlsafe_id}").click # why thoes this not work?
+  end
+end
+
+def visit_go_solo(_team)
+  visit current_teams_url
+
+  page.within("#current_teams") do
+    click_button("Go solo")
+  end
+end
+
+#
+#
+# RSpec / Rails System spec "get response" methods
+#
+def switch_current_team(team)
+  post current_teams_path, params: { current_team: { team_yid: team.yid } }
+end
+
+def go_solo(team)
+  delete current_team_path(team) # , method: :delete
+end


### PR DESCRIPTION
# Implements authentication with email / password credentials

* Closes https://github.com/mediafinger/yournaling/issues/14
* Users can now login and logout
* per default a Guest User ("NullObject") is being used 
* Users can select one of their teams, which will be stored in the session
* helpers for `current_user`, `current_team` and `current_member` available
* this will allow to scope (almost) all actions to a team 
  * therefore the team can become the owner of all entities (like pictures, locations, etc...)
  * the user will only be stored as "uploader" or "creator" or "editor"

## TODO

- [x] fix broken request specs / add spec helpers
- [x] add a few request specs
- [x] use "null object" guest user?
- [x] allow guest users on certain pages (or just stick to current_user = nil ?)
- [x] avoid "Logout Guest" link, instead show "Login" button