### PR TITLE
Validate image dimensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "puma", "~> 6.3"
 gem "rack-requestid", "~> 0.2" # always set a request_id with this middleware
 gem "rack-timeout", "~> 0.6", require: "rack/timeout/base" # set a custom timeout in the middleware
 gem "redis", "~> 5.0" # Use Redis for Action Cable / Turbo-Reflex
+gem "ruby-vips" # Use ruby-vips for image processing with ActiveStorage, requires the vips library
 gem "sprockets-rails" # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "stimulus-rails" # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "strong_migrations", "~> 1.6" # Catch unsafe migrations in development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,6 +421,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.21)
   rubocop-rake (~> 0.6)
   rubocop-rspec (~> 2.6)
+  ruby-vips
   selenium-webdriver (~> 4.14)
   sprockets-rails
   stimulus-rails

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -30,6 +30,15 @@ class PicturesController < ApplicationController
       raise CustomError.new("File not valid", status: 422, code: :unprocessable_entity)
     end
 
+    # IDEA
+    # upload AND validate original picture
+    # store original picture if valid
+    # in a background job, create an XL / 4k variant with up to 4000x4000 pixels
+    # and replace the original file attachment with the webp 4k variant
+    # rely on dependent: :purge_later to delete the original picture
+    # the variants can be cropped to fit the desired aspect ratio for all preview images on the website
+    # create the other variants (consider portrait, square, landscape orginal picture aspect ratios)
+    #
     @picture = Picture.new(
       file: ImageUploadConversionService.call(file: picture_params[:file], name: picture_params[:name]),
       name: picture_params[:name], # looks redundant, but image filename is parameterized

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -14,6 +14,10 @@ class Picture < ApplicationRecordYidEnabled
   ALLOWED_CONTENT_TYPES = ALLOWED_IMAGE_TYPES.map { |type| "image/#{type}" }.freeze
   MAX_BYTE_SIZE = 6.megabytes.freeze
   MIN_BYTE_SIZE = 150.kilobytes.freeze
+  MAX_PIXEL_HEIGHT = 4000
+  MIN_PIXEL_HEIGHT = 400
+  MAX_PIXEL_WIDTH = 4000
+  MIN_PIXEL_WIDTH = 400
   YID_CODE = "pic".freeze
 
   belongs_to :team, foreign_key: "team_yid", primary_key: "yid", inverse_of: :pictures
@@ -21,7 +25,7 @@ class Picture < ApplicationRecordYidEnabled
   normalizes :name, with: ->(name) { name.strip }
 
   # NOTE
-  # In PicturesController#create the uploaded files are resized (downsized) to to max of 4000x3000
+  # In PicturesController#create the uploaded files are resized (downsized) to max of MAX_PIXEL_WIDTH x MAX_PIXEL_HEIGHT
   # and converted to .webp with a quality of 90% with the ImageUploadConversionService
   # *before* being saved to disk.
   #
@@ -29,7 +33,7 @@ class Picture < ApplicationRecordYidEnabled
   # uses the active_storage_validations gem
   # currently allowing all content_types, not only webp which it should be after conversion
   #
-  # TODO: add validations for aspect_ratio and dimensions, see: https://github.com/igorkasyanchuk/active_storage_validations
+  # see: https://github.com/igorkasyanchuk/active_storage_validations
   #
   validates :file, attached: true,
     size: {
@@ -47,7 +51,19 @@ class Picture < ApplicationRecordYidEnabled
         "errors.messages.content_type_invalid",
         allowed_types: ALLOWED_IMAGE_TYPES.join(", ")
       ),
+    },
+    dimension: {
+      width: {
+        min: MIN_PIXEL_WIDTH, max: MAX_PIXEL_WIDTH,
+        message: I18n.t("errors.messages.dimension_width_inclusion", min: MIN_PIXEL_WIDTH, max: MAX_PIXEL_WIDTH)
+      },
+      height: {
+        min: MIN_PIXEL_HEIGHT, max: MAX_PIXEL_HEIGHT,
+        message: I18n.t("errors.messages.dimension_height_inclusion", min: MIN_PIXEL_HEIGHT, max: MAX_PIXEL_HEIGHT)
+      },
     }
+  # TODO: add validation to allow range of aspect ratios (e.g. width / height between 2/3 and 3/2)
+  # TODO: or crop original image to fit landscape / square / portrait variants
 
   validates :name, allow_blank: true, length: { maximum: 255 }
 

--- a/app/services/image_upload_conversion_service.rb
+++ b/app/services/image_upload_conversion_service.rb
@@ -44,12 +44,14 @@ class ImageUploadConversionService
     # inspired by: https://vitobotta.com/2020/09/24/resize-and-optimise-images-on-upload-with-activestorage/
     #
     def resize_and_convert_before_storage(file)
-      # TODO: check file size in pixels and fail when too small? e.g. less than 800x600 pixels
+      # TODO: check file size in pixels and fail when too small? e.g. less than
+      #       Picture::MIN_PIXEL_WIDTH x Picture::MIN_PIXEL_HEIGHT pixels
       # TODO: check conversion to WebP for all images - lossless for PNG and GIF, lossy for JPEG and TIFF ?
       #       or at least keep transparency for PNGs and GIFs? (but no animated GIFs)
       # TODO: only replace when downsized is smaller than original ?! Would need checks on pixel size as well as file size.
 
-      ImageProcessing::Vips.source(file.tempfile).resize_to_limit(4000, 3000).convert("webp").saver(quality: 90).call!
+      ImageProcessing::Vips.source(file.tempfile).resize_to_limit(Picture::MAX_PIXEL_WIDTH,
+        Picture::MAX_PIXEL_HEIGHT).convert("webp").saver(quality: 90).call!
     end
   end
 end


### PR DESCRIPTION
Add validation for image min and max dimensions.

Still missing: allowed aspect ratios - ideally something like width / height must be between 2/3 to 3/2...

Currently only the already converted (downsized) image is validated - which makes this somewhat useless.