### PR TITLE
Implement forward and reverse geocoding with Geocoder gem and Geoapify API

### DIFF
--- a/.active_record_doctor
+++ b/.active_record_doctor
@@ -48,16 +48,13 @@ ActiveRecordDoctor.configure do
     good_jobs.retried_good_job_id
   ]
 
-  detector :missing_non_null_constraint, ignore_columns: %w[]
+  detector :missing_non_null_constraint, ignore_columns: %w[
+  ]
 
   detector :missing_presence_validation, ignore_attributes: %w[
     GoodJob::DiscreteExecution.active_job_id
     GoodJob::Job.id
-    RecordHistory.event
-    RecordHistory.record_type
-    RecordHistory.record_yid
-    RecordHistory.team_yid
-    RecordHistory.user_yid
+    Location.geocoded_address
   ]
 
   detector :short_primary_key_type, ignore_tables: %w[

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ AllCops:
     - "**/vendor/**/*"
     - "config/environments/**/*" # generated files
     - "config/initializers/new_framework_defaults*" # generated files
+    - "config/initializers/geocoder.rb" # generated file
     - "db/schema.rb" # generated file
     - "spec/rails_helper.rb"
     - "spec/spec_helper.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "bootsnap", require: false
 gem "countries", "~> 6.0" # Lists of countries, their ISO codes, emoji flags and more
 gem "dry-validation", "~> 1.10" # Use dry-validation for validations [https://dry-rb.org/gems/dry-validation]
 # gem "exifr", "~> 1.3" # Read EXIF metadata from JPEG images
+gem "geocoder" # (reverse) geocode addresses and GPS coordinates
 gem "good_job" # Use good_job as active_job backend for a simpler setup with queueing in postgres
 gem "image_processing", "~> 1.12" # Use image_processing for image resizing in ActiveStorage variants
 gem "importmap-rails", "~> 1.2" # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     fugit (1.10.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
+    geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     good_job (3.26.2)
@@ -409,6 +410,7 @@ DEPENDENCIES
   factory_bot-awesome_linter (~> 1.0)
   factory_bot_rails (~> 6.2)
   faker (~> 3.2)
+  geocoder
   good_job
   image_processing (~> 1.12)
   importmap-rails (~> 1.2)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -16,4 +16,7 @@ class Location < ApplicationRecordYidEnabled
   validates :team_yid, presence: true, uniqueness: { scope: :name }
   validates :name, presence: true, uniqueness: { scope: :team_yid }
   validates :url, presence: true # TODO: ensure URL valid or check for 200 response?
+
+  # Geocoder.search(address, params: {filter: "countrycode:country_code" })
+  # "https://api.geoapify.com/v1/geocode/search?text=#{address}&filter=countrycode:#{country_code}&apiKey=#{AppConf.geoapify_api_key}"
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,18 +5,119 @@ class Location < ApplicationRecordYidEnabled
 
   normalizes :country_code, with: ->(country_code) { country_code.strip.downcase }
   normalizes :name, with: ->(name) { name.strip }
-  normalizes :url, with: ->(url) { ActionDispatch::Http::URL.full_url_for(host: url.strip, protocol: "https") }
+  normalizes :url, with: ->(url) {
+    ActionDispatch::Http::URL.full_url_for(host: url.strip, protocol: "https") if url.present?
+  }, apply_to_nil: false
 
-  # validates :address # TODO: with dry-schema
+  validate :address_or_coordinates_or_url_given
   validates :country_code, presence: true, inclusion: { in: CountriesEnForSelectService.call.keys }
   validates :lat, allow_nil: true,
     numericality: { greater_than_or_equal_to: BigDecimal("-90.0"), less_than_or_equal_to: BigDecimal("90.0") }
   validates :long, allow_nil: true,
     numericality: { greater_than_or_equal_to: BigDecimal("-180.0"), less_than_or_equal_to: BigDecimal("180.0") }
-  validates :team_yid, presence: true, uniqueness: { scope: :name }
   validates :name, presence: true, uniqueness: { scope: :team_yid }
-  validates :url, presence: true # TODO: ensure URL valid or check for 200 response?
+  validates :team_yid, presence: true, uniqueness: { scope: :name }
 
-  # Geocoder.search(address, params: {filter: "countrycode:country_code" })
+  after_validation :geocode, if: ->(location) { calculate_coordinates?(location) }
+  after_validation :reverse_geocode, if: ->(location) { get_address?(location) }
+  after_validation :create_gmaps_url, if: ->(location) { location.url.nil? }
+  after_validation :set_address, if: ->(location) { location.address.blank? }
+
+  # NOTE: this adds the `geocode` method
+  geocoded_by :address_with_cc do |location, results|
+    next unless results.any?
+
+    geocoding_result = results.first.data["properties"] # ignore other API results
+
+    location.lat = geocoding_result["lat"]
+    location.long = geocoding_result["lon"]
+    location.country_code = geocoding_result["country_code"]
+    location.geocoded_address[:country_code] = geocoding_result["country_code"]
+  end
+
+  reverse_geocoded_by :lat, :long do |location, results|
+    next unless results.any?
+
+    geocoding_result = results.first.data["properties"] # ignore other API results
+
+    location.country_code = geocoding_result["country_code"]
+    # NOTE: depending on the result more or less information will be returned
+    location.geocoded_address[:name] = geocoding_result["name"] || geocoding_result["result_type"]
+    location.geocoded_address[:country_code] = geocoding_result["country_code"]
+    location.geocoded_address[:state] = geocoding_result["state"]
+    location.geocoded_address[:state_district] = geocoding_result["state_district"]
+    location.geocoded_address[:county] = geocoding_result["county"]
+    location.geocoded_address[:zip_code] = geocoding_result["postcode"]
+    location.geocoded_address[:city] = geocoding_result["city"]
+    location.geocoded_address[:city_district] = geocoding_result["district"]
+    location.geocoded_address[:city_neighbourhood] = geocoding_result["neighbourhood"]
+    location.geocoded_address[:city_suburb] = geocoding_result["suburb"]
+    location.geocoded_address[:street] = geocoding_result["street"]
+    location.geocoded_address[:housenumber] = geocoding_result["housenumber"]
+    location.geocoded_address[:lat] = geocoding_result["lat"]
+    location.geocoded_address[:long] = geocoding_result["lon"]
+    location.geocoded_address[:full_address] = geocoding_result["formatted"]
+  end
+
+  # Geocoder.search(address, params: {bias: "countrycode:country_code" })
   # "https://api.geoapify.com/v1/geocode/search?text=#{address}&filter=countrycode:#{country_code}&apiKey=#{AppConf.geoapify_api_key}"
+
+  def coordinates
+    [lat, long]
+  end
+
+  def coordinates_changed?
+    lat_changed? || long_changed?
+  end
+
+  def gmaps_coordinates_url
+    "https://www.google.com/maps/place/#{lat},#{long}"
+  end
+
+  private
+
+  def address_with_cc
+    [address, country_code&.upcase].compact.join(", ")
+  end
+
+  def address_or_coordinates_or_url_given
+    return if address.present? || (lat.present? && long.present?) || url.present?
+
+    errors.add(:base, "Address, Coordinates, or URL must be provided")
+  end
+
+  def create_gmaps_url
+    self.url = gmaps_coordinates_url
+  end
+
+  # NOTE: calculate new coordinates when the address changes, unless the coordinates have been changed as well
+  def calculate_coordinates?(location)
+    return location.coordinates.compact.blank? && location.address.present? if location.new_record?
+
+    location.country_code_changed? ||
+      location.address.present? && location.address_changed? && !location.coordinates_changed?
+  end
+
+  # NOTE: fetch new address when the coordinates change, unless the address has been changed as well
+  def get_address?(location)
+    return location.address.blank? && location.coordinates.present? if location.new_record?
+
+    location.country_code_changed? ||
+      location.coordinates.present? && location.coordinates_changed? && !location.address_changed?
+  end
+
+  def set_address
+    self.address = geocoded_address[:full_address]
+
+    return if address.present?
+
+    self.address = [
+      geocoded_address[:street],
+      geocoded_address[:housenumber],
+      geocoded_address[:zip_code],
+      geocoded_address[:city],
+      geocoded_address[:county],
+      geocoded_address[:state],
+    ].compact.join(", ")
+  end
 end

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -38,6 +38,8 @@
         <%= form.text_field :long %>
       </div>
 
+      <%# TODO: display Powered by <a href="https://www.geoapify.com/">Geoapify</a>  %>
+
       <div>
         <%= form.label :description %>
         <%= form.text_area :description %>

--- a/config/app_conf.rb
+++ b/config/app_conf.rb
@@ -135,12 +135,15 @@ class AppConf
   register :amazon_s3_secret_access_key, default: "secret_access_key", required: production_env
   register :amazon_s3_bucket_name, default: "yournaling", required: production_env
 
+  # Geoapify API
+  register :geoapify_api_key, default: "secret_key", required: production_env
+
   # Don't add secrets as 'default' values in this file!
   #
   # Either set ENV vars for secrets on the server
   #   or for local usage add them to the following file, which is in .gitignore:
   #
-  load "config/app_conf.local.rb" if File.exist?("config/app_conf.local.rb")
+  load "config/app_conf.local.rb" if !is?(:environment, :test) && File.exist?("config/app_conf.local.rb")
   #
   # inside use this syntax:
   #   AppConf.set :password, "secret"

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -80,10 +80,14 @@ if AppConf.is?(:environment, :test)
   Geocoder::Lookup::Test.add_stub(
     "New York, US", [
       {
-        "coordinates"  => [40.7143528, -74.0059731],
-        "address"      => "New York, NY, USA",
-        "country"      => "United States",
-        "country_code" => "US",
+        "properties" => {
+          "coordinates"  => [40.7143528, -74.0059731],
+          "lat"          => 40.7143528,
+          "lon"          => -74.0059731,
+          "address"      => "New York, NY, USA",
+          "country"      => "United States",
+          "country_code" => "US",
+        },
       },
     ]
   )
@@ -91,10 +95,14 @@ if AppConf.is?(:environment, :test)
   Geocoder::Lookup::Test.set_default_stub(
     [
       {
-        "coordinates"  => [45.0, 0.0],
-        "address"      => "33660 Puynormand, France",
-        "country"      => "France",
-        "country_code" => "FR",
+        "properties" => {
+          "coordinates"  => [45.0, 0.0],
+          "lat"          => 45.0,
+          "lon"          => 0.0,
+          "address"      => "33660 Puynormand, France",
+          "country"      => "France",
+          "country_code" => "FR",
+        },
       },
     ]
   )

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,101 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)
+
+
+
+Geocoder.configure(
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+
+  # configure services
+  timeout: 2,
+  cache: nil,                   # cache object (must respond to #[], #[]=, and #del) / use Redis?!
+  language: :en,                # ISO-639 language code
+  use_https: true,              # use HTTPS for lookup requests? (if supported)
+
+  lookup: :geoapify,            # name of geocoding service (symbol)
+
+  # https://github.com/alexreisner/geocoder/blob/master/README_API_GUIDE.md#geoapify-geoapify
+  geoapify: {
+    api_key: AppConf.geoapify_api_key,
+    timeout: 2,
+    limit: 5,
+    autocomplete: true
+  },
+
+  # raisable exceptions:
+  #
+  # SocketError
+  # Timeout::Error
+  # Geocoder::OverQueryLimitError
+  # Geocoder::RequestDenied
+  # Geocoder::InvalidRequest
+  # Geocoder::InvalidApiKey
+  # Geocoder::ServiceUnavailable
+  #
+  always_raise: :all,
+
+  # Calculation options
+  units: :km,                 # :km for kilometers or :mi for miles
+  distances: :spherical,         # :spherical or :linear
+
+  # Cache configuration
+  cache_options: {
+    expiration: 8.days,
+    prefix: "geocoding:",
+  },
+)
+
+# set stubs for development and test environments, instead of using a real API
+#
+if AppConf.is?(:environment, :test)
+  Geocoder.configure(lookup: :test)
+
+  Geocoder::Lookup::Test.add_stub(
+    "New York, US", [
+      {
+        "coordinates"  => [40.7143528, -74.0059731],
+        "address"      => "New York, NY, USA",
+        "country"      => "United States",
+        "country_code" => "US",
+      },
+    ]
+  )
+
+  Geocoder::Lookup::Test.set_default_stub(
+    [
+      {
+        "coordinates"  => [45.0, 0.0],
+        "address"      => "33660 Puynormand, France",
+        "country"      => "France",
+        "country_code" => "FR",
+      },
+    ]
+  )
+end

--- a/db/migrate/20240323124211_add_geocoded_address_to_locations.rb
+++ b/db/migrate/20240323124211_add_geocoded_address_to_locations.rb
@@ -1,0 +1,13 @@
+class AddGeocodedAddressToLocations < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured { change_column :locations, :address, :string, null: true, default: nil }
+    add_column :locations, :geocoded_address, :jsonb, null: false, default: {}
+    change_column_null :locations, :url, true
+  end
+
+  def down
+    safety_assured { change_column :locations, :address, :json, null: false, default: {} }
+    add_column :locations, :geocoded_address, :jsonb, null: false, default: {}
+    change_column_null :locations, :url, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_23_091155) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_23_124211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -123,16 +123,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_23_091155) do
   end
 
   create_table "locations", primary_key: "yid", id: :string, force: :cascade do |t|
-    t.json "address", default: {}
+    t.string "address"
     t.string "country_code", null: false
     t.datetime "created_at", null: false
     t.string "description"
+    t.jsonb "geocoded_address", default: {}, null: false
     t.decimal "lat"
     t.decimal "long"
     t.string "name", null: false
     t.string "team_yid", null: false
     t.datetime "updated_at", null: false
-    t.text "url", null: false
+    t.text "url"
     t.index ["country_code"], name: "index_locations_on_country_code"
     t.index ["team_yid", "name"], name: "index_locations_on_team_yid_and_name", unique: true
   end

--- a/spec/factories/locations_factory.rb
+++ b/spec/factories/locations_factory.rb
@@ -5,13 +5,6 @@ FactoryBot.define do
     address { Faker::Address.full_address }
     lat { rand(-90.0...90.0).round(10) }
     long { rand(-180.0...180.0).round(10) }
-    # url
-    # description
-
     team
-
-    after(:build) do |location, _params|
-      location.url = "https://www.google.de/maps/place/#{location.long},#{location.lat}"
-    end
   end
 end

--- a/spec/views/locations/show.html.erb_spec.rb
+++ b/spec/views/locations/show.html.erb_spec.rb
@@ -1,20 +1,22 @@
 require "rails_helper"
 
 RSpec.describe "locations/show", type: :view do
-  let(:lat) { 41.3819253 }
-  let(:long) { 2.1656894 }
-  let(:team) { FactoryBot.create(:team) }
-
-  before do
-    assign(:location, Location.create!(
+  let(:location) do
+    Location.create!(
       name: "Flat in Carrer Ferlandina",
       country_code: "es",
       address: {},
       lat: lat,
       long: long,
-      url: "https://www.google.de/maps/place/#{long},#{lat}",
       team: team
-    ))
+    )
+  end
+  let(:lat) { 41.3819253 }
+  let(:long) { 2.1656894 }
+  let(:team) { FactoryBot.create(:team) }
+
+  before do
+    assign(:location, location.reload)
   end
 
   it "renders attributes in <p>" do
@@ -24,6 +26,6 @@ RSpec.describe "locations/show", type: :view do
     expect(rendered).to match(/{}/)
     expect(rendered).to match(/#{lat}/)
     expect(rendered).to match(/#{long}/)
-    expect(rendered).to match(%r{https://www.google.de/maps/place/2.1656894,41.3819253})
+    expect(rendered).to match(%r{https://www.google.com/maps/place/41.3819253,2.1656894})
   end
 end


### PR DESCRIPTION
This PR will  (at least partly) superseed the outdated:

* https://github.com/mediafinger/yournaling/pull/8

## TODOs

- [x] decide how to handle forward and reverse geocoding
- [x] decide when to display lat & long form fields
- [x] implement geocoding requests
- [x] store geocoded address data in new database fields

## For future improvement:

- [ ] implement autocomplete query