### PR TITLE
Add Memory and Content Visibility concept

### DIFF
--- a/.active_record_doctor
+++ b/.active_record_doctor
@@ -27,20 +27,20 @@ ActiveRecordDoctor.configure do
   # Detector-specific settings affect only one specific detector.
   # detector :extraneous_indexes, ignore_tables: ["users"], ignore_indexes: ["accounts_on_email_organization_id"]
 
-  detector :incorrect_length_validation, ignore_attributes: [
-    # app only validation sufficient, no need to enforce length in DB
-    "Picture.name",
-    "Picture.yid",
-    "Team.name",
-    "Team.yid",
-    "User.email",
-    "User.name",
-    "User.nickname",
-    "User.password_digest",
-    "User.yid",
-
-    "User.temp_auth_token", # for some reason DB Doctor complains about a (non) existing validation on this column?!
-  ]
+  # app only validation sufficient, no need to enforce length in DB
+  detector :incorrect_length_validation, ignore_attributes: %w[
+    Memory.memo
+    Picture.name
+    Picture.yid
+    Team.name
+    Team.yid
+    User.email
+    User.name
+    User.nickname
+    User.password_digest
+    User.yid
+    User.temp_auth_token
+  ] # for some reason DB Doctor complains about a (non) existing validation on User.temp_auth_token column?!
 
   detector :missing_foreign_keys, ignore_columns: %w[
     good_jobs.active_job_id
@@ -74,5 +74,8 @@ ActiveRecordDoctor.configure do
   # # Ignore indexes that are not used in the application
   detector :unindexed_foreign_keys, ignore_columns: %w[
     good_jobs.retried_good_job_id
+    memories.location_yid
+    memories.picture_yid
+    memories.weblink_yid
   ]
 end

--- a/TODO.markdown
+++ b/TODO.markdown
@@ -50,7 +50,7 @@ Yournaling should become a travel journal, where we can:
 * team_yid (owned_by)
 * timestamps (created_at, updated_at)
 * user_yid (created_by)
-* visibility (draft, internal, public, unpublished, blocked, deleted - not used on Includes or Insights) 
+* visibility (draft, internal, published, archived, blocked - not used on Includes or Insights) 
 
 #### An visibility_changed_log will contain additional metadata:
 
@@ -59,8 +59,8 @@ Yournaling should become a travel journal, where we can:
 * team_yid (owned_by)
 * user_yid (visiblity_changed_by)
 * visiblity_changed_at (timestamp)
-* visiblity_changed_from (draft, internal, public, unpublished, blocked, deleted)
-* visiblity_changed_to (draft, internal, public, unpublished, blocked, deleted)
+* visiblity_changed_from (draft, internal, published, archived, blocked)
+* visiblity_changed_to (draft, internal, published, archived, blocked)
 
 > When a moderator blocks or deletes content, Pictures and Links could be included in other content and need extra treatment.
 
@@ -94,8 +94,8 @@ Yournaling should become a travel journal, where we can:
 
 ### Memories
 
-* must contain memo 
-* must contain at least one insight of and not more than one per type:
+* must contain memo (limited to 500 characters, minimum 4?)
+* can contain one insight of each type:
   * picture
   * (geo) location
   * website link
@@ -103,7 +103,7 @@ Yournaling should become a travel journal, where we can:
 ### Chronicles
 
 * must contain headline
-* must contain notes
+* must contain notes (limited to 20_000 characters?, minimum 20?)
 * can contain multiple insights of:
   * pictures
   * (geo) locations
@@ -198,8 +198,8 @@ Yournaling should become a travel journal, where we can:
 * included_id
 * team_yid (owner)
 * user_yid (included_by)
-* visiblity_status_included (draft, internal, public, unpublished)
-* visiblity_status_wrapper (draft, internal, public, unpublished)
+* visiblity_status_included (draft, internal, published, archived, blocked)
+* visiblity_status_wrapper (draft, internal, published, archived, blocked)
 * wrapper_id
 
 
@@ -254,11 +254,11 @@ Yournaling should become a travel journal, where we can:
 * internal
   * now also visible to team members with the reader role
   * this should clearly be a paid feature
-* public
+* published
   * visible to everyone on the platform
   * visible to everyone in the whole wide world
-* unpublished
-  * like draft, but has been published before
+* archived
+  * like draft, but listed team internally in extra section
 * blocked
   * when content violates the rules, a platform-moderator can block the content
   * it will be treated like unplished, but visiblity can not be changed anymore

--- a/app/controllers/content_visibility_controller.rb
+++ b/app/controllers/content_visibility_controller.rb
@@ -1,0 +1,28 @@
+class ContentVisibilityController < ApplicationController
+  def edit
+    @content = ApplicationRecordYidEnabled.fynd(Base64.urlsafe_decode64(params[:id]))
+    authorize! @content, to: :read?
+
+    @visibility_states = @content.class::VISIBILITY_STATES - %w[draft blocked]
+  end
+
+  def update
+    @content = ApplicationRecordYidEnabled.fynd(Base64.urlsafe_decode64(params[:id]))
+    @content.visibility = update_params[:visibility]
+    authorize! @content, to: :update?, with: ContentVisibilityPolicy
+
+    Memory.update_with_history(record: @content, history_params: { team: current_team, user: current_user })
+
+    if @content.changed? # == content still dirty, not saved
+      render :edit, status: :unprocessable_entity
+    else
+      redirect_to @content, notice: "Memory was successfully updated."
+    end
+  end
+
+  private
+
+  def update_params
+    params.permit(:visibility)
+  end
+end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,0 +1,70 @@
+class MemoriesController < ApplicationController
+  def index
+    authorize! current_user, to: :index?, with: MemoryPolicy
+
+    # memories = authorized_scope(Memory.all, type: :relation, as: :current_team_scope)
+
+    @memories = Memory.includes(:team, :picture, :location, :weblink).all
+  end
+
+  def show
+    @memory = Memory.urlsafe_find!(params[:id])
+    authorize! @memory
+  end
+
+  def new
+    @memory = Memory.new(team: current_team)
+    authorize! @memory
+  end
+
+  def edit
+    @memory = Memory.urlsafe_find!(params[:id])
+    authorize! @memory
+  end
+
+  def create
+    @memory = Memory.new(create_params.compact_blank.merge(team: current_team))
+    authorize! @memory
+
+    Memory.create_with_history(record: @memory, history_params: { team: current_team, user: current_user })
+
+    if @memory.persisted?
+      redirect_to @memory, notice: "Memory was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @memory = Memory.urlsafe_find!(params[:id])
+    authorize! @memory
+    @memory.assign_attributes(update_params.compact_blank)
+
+    Memory.update_with_history(record: @memory, history_params: { team: current_team, user: current_user })
+
+    if @memory.changed? # == memory still dirty, not saved
+      render :edit, status: :unprocessable_entity
+    else
+      redirect_to @memory, notice: "Memory was successfully updated."
+    end
+  end
+
+  def destroy
+    @memory = Memory.urlsafe_find!(params[:id])
+    authorize! @memory
+
+    Memory.destroy_with_history(record: @memory, history_params: { team: current_team, user: current_user })
+
+    redirect_to memories_url, notice: "Memory was successfully destroyed."
+  end
+
+  private
+
+  def create_params
+    params.require(:memory).permit(:team_yid, :memo, :picture_yid, :location_yid, :weblink_yid)
+  end
+
+  def update_params
+    params.require(:memory).permit(:memo, :picture_yid, :location_yid, :weblink_yid)
+  end
+end

--- a/app/models/application_record_for_content.rb
+++ b/app/models/application_record_for_content.rb
@@ -1,0 +1,46 @@
+class ApplicationRecordForContent < ApplicationRecordYidEnabled
+  self.abstract_class = true
+  self.primary_key = "yid"
+
+  VISIBILITY_STATES = %w[draft internal published archived blocked].freeze
+  YID_CODE = "abstract_class_must_not_be_used".freeze
+
+  after_initialize :define_visibility_methods
+
+  private
+
+  # NOTE: defines methods draft? internal? published? archived? blocked?
+  # on the descendant classes
+  def define_visibility_methods
+    return unless self.class.column_names.include?("visibility")
+
+    VISIBILITY_STATES.each do |vs|
+      self.class.send(:define_method, :"#{vs}?") do
+        visibility.to_s == vs.to_s
+      end
+    end
+  end
+end
+
+__END__
+
+## Visibility of content
+
+* draft
+  * visible to: team member with owner, manager, editor or publisher role and the creator themselves
+  * default state for all new content
+* internal
+  * now also visible to team members with the reader role
+  * this should clearly be a paid feature
+* published
+  * visible to everyone on the platform
+  * visible to everyone in the whole wide world
+* archived
+  * like draft, but not listed with them, but in an extra section
+* blocked
+  * when content violates the rules, a platform-moderator can block the content
+  * it will be treated like archieved, but visiblity can not be changed by team anymore
+  * only after a change and a review a platform-moderator can unblock the content again
+  * maybe automatic blocking after multiple user-reports
+* only team members with the publisher role can publish content to people outside their team
+* owners, managers and publishers can unpublish content

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,6 +3,9 @@ class Location < ApplicationRecordYidEnabled
 
   belongs_to :team, inverse_of: :locations, foreign_key: "team_yid"
 
+  has_many :memories, class_name: "Memory", foreign_key: "location_yid", primary_key: "yid", inverse_of: :location,
+    dependent: :nullify
+
   multisearchable(
     against: %i[name country_code address],
     additional_attributes: ->(location) { { team_yid: location.team_yid } }

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -1,0 +1,23 @@
+class Memory < ApplicationRecordForContent
+  YID_CODE = "memo".freeze
+
+  belongs_to :team, inverse_of: :memories, foreign_key: "team_yid"
+  belongs_to :location, inverse_of: :memories, foreign_key: "location_yid", optional: true
+  belongs_to :picture, inverse_of: :memories, foreign_key: "picture_yid", optional: true
+  belongs_to :weblink, inverse_of: :memories, foreign_key: "weblink_yid", optional: true
+
+  multisearchable(
+    against: %i[memo],
+    additional_attributes: ->(memory) { { team_yid: memory.team_yid } }
+  )
+
+  attr_readonly :team_yid
+
+  normalizes :memo, with: ->(memo) { memo.strip }
+
+  validates :memo, presence: true, length: { minimum: 4, maximum: 500 }
+  validates :location, presence: true, if: -> { location_yid.present? }
+  validates :picture, presence: true, if: -> { picture_yid.present? }
+  validates :weblink, presence: true, if: -> { weblink_yid.present? }
+  validates :visibility, presence: true, inclusion: { in: VISIBILITY_STATES }
+end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -22,6 +22,9 @@ class Picture < ApplicationRecordYidEnabled
 
   belongs_to :team, foreign_key: "team_yid", primary_key: "yid", inverse_of: :pictures
 
+  has_many :memories, class_name: "Memory", foreign_key: "picture_yid", primary_key: "yid", inverse_of: :picture,
+    dependent: :nullify
+
   multisearchable(
     against: %i[name],
     additional_attributes: ->(picture) { { team_yid: picture.team_yid } }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,6 +5,8 @@ class Team < ApplicationRecordYidEnabled
     dependent: :destroy
   has_many :members, class_name: "Member", foreign_key: "team_yid", primary_key: "yid", inverse_of: :team,
     dependent: :destroy
+  has_many :memories, class_name: "Memory", foreign_key: "team_yid", primary_key: "yid", inverse_of: :team,
+    dependent: :destroy
   has_many :pictures, class_name: "Picture", foreign_key: "team_yid", primary_key: "yid", inverse_of: :team,
     dependent: :destroy
   has_many :weblinks, class_name: "Weblink", foreign_key: "team_yid", primary_key: "yid", inverse_of: :team,

--- a/app/models/weblink.rb
+++ b/app/models/weblink.rb
@@ -3,6 +3,9 @@ class Weblink < ApplicationRecordYidEnabled
 
   belongs_to :team, inverse_of: :weblinks, foreign_key: "team_yid"
 
+  has_many :memories, class_name: "Memory", foreign_key: "weblink_yid", primary_key: "yid", inverse_of: :weblink,
+    dependent: :nullify
+
   multisearchable(
     against: %i[name],
     additional_attributes: ->(weblink) { { team_yid: weblink.team_yid } }

--- a/app/policies/content_visibility_policy.rb
+++ b/app/policies/content_visibility_policy.rb
@@ -1,0 +1,16 @@
+class ContentVisibilityPolicy < ApplicationPolicy
+  def update?
+    return false unless current_team_owns_record?
+
+    case record.visibility
+    when "internal"
+      with_role?(:owner, :manager, :editor, :publisher)
+    when "published"
+      with_role?(:publisher)
+    when "archived"
+      with_role?(:owner, :manager, :publisher)
+    else
+      false
+    end
+  end
+end

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -1,0 +1,19 @@
+class MemoryPolicy < ApplicationPolicy
+  def read?
+    return true if current_team_owns_record?
+
+    record.published?
+  end
+
+  def create?
+    current_team_owns_record? && with_role?(:owner, :manager, :editor)
+  end
+
+  def update?
+    current_team_owns_record? && with_role?(:owner, :manager, :editor)
+  end
+
+  def destroy?
+    current_team_owns_record? && with_role?(:owner, :manager)
+  end
+end

--- a/app/view_components/application_nav_component.rb
+++ b/app/view_components/application_nav_component.rb
@@ -20,6 +20,6 @@ class ApplicationNavComponent < ApplicationComponent
   ERB
 
   def initialize
-    @sections = %w[pictures locations weblinks members]
+    @sections = %w[memories pictures locations weblinks members]
   end
 end

--- a/app/views/content_visibility/_form.html.erb
+++ b/app/views/content_visibility/_form.html.erb
@@ -1,0 +1,18 @@
+<article>
+  <%= form_with( url: content_visibility_path, method: :patch) do |form| %>
+    <%= render partial: "shared_partials/form_validation_errors", locals: { record: content } %>
+
+    <fieldset>
+      <h3><legend><%= form_legend %></legend></h3>
+
+      <div>
+        <%= form.label :visibility %>
+        <%= form.select :visibility, @visibility_states, selected: content.visibility %>
+      </div>
+
+      <div>
+        <%= form.submit %>
+      </div>
+    </fieldset>
+  <% end %>
+</article>

--- a/app/views/content_visibility/edit.html.erb
+++ b/app/views/content_visibility/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { content: @content, form_legend: "Edit content visibility"} %>

--- a/app/views/memories/_action_buttons.html.erb
+++ b/app/views/memories/_action_buttons.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "New memory", new_memory_path, role: "button" %>

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -1,0 +1,39 @@
+<article>
+  <%= form_with(model: memory) do |form| %>
+    <%= render partial: "shared_partials/form_validation_errors", locals: { record: memory } %>
+
+    <fieldset>
+      <h3><legend><%= form_legend %></legend></h3>
+
+      <div>
+        <%= form.label :memo %>
+        <%= form.text_area :memo, rows: 4, require: true %>
+      </div>
+
+      <div>
+        <%= form.label :picture_yid %>
+        <%=
+          form.select :picture_yid, Picture.pluck(:name, :yid), selected: form.object.picture_yid, include_blank: true
+        %>
+      </div>
+
+      <div>
+        <%= form.label :location_yid %>
+        <%=
+          form.select :location_yid, Location.pluck(:name, :yid), selected: form.object.location_yid, include_blank: true
+        %>
+      </div>
+
+      <div>
+        <%= form.label :weblink_yid %>
+        <%=
+          form.select :weblink_yid, Weblink.pluck(:name, :yid), selected: form.object.weblink_yid, include_blank: true
+        %>
+      </div>
+
+      <div>
+        <%= form.submit %>
+      </div>
+    </fieldset>
+  <% end %>
+</article>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -1,0 +1,29 @@
+<article id="<%= dom_id memory %>">
+  <p>
+    <strong>Team:</strong>
+    <%= memory.team.name %>
+  </p>
+
+  <p>
+    <strong>Memo:</strong>
+    <%= memory.memo %>
+  </p>
+
+  <% if memory.picture %>
+    <%= render partial: "pictures/picture", locals: { picture: memory.picture } %>
+  <% end %>
+
+  <% if memory.location %>
+    <%= render partial: "locations/location", locals: { location: memory.location } %>
+  <% end %>
+
+  <% if memory.weblink %>
+    <%= render partial: "weblinks/weblink", locals: { weblink: memory.weblink } %>
+  <% end %>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this memory", memory, role: "button"  %>
+  <% end %>
+  <%= link_to 'Edit this memory', edit_memory_path(memory), role: "button", class: "secondary" %>
+  <%= link_to 'Change visibility', edit_content_visibility_path(memory), role: "button", class: "secondary" %>
+</article>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: "form", locals: { memory: @memory, form_legend: "Edit memory"} %>
+
+<%= link_to "Show this memory", @memory, role: "button"  %>
+<%= button_to "Destroy this memory", memory_path(@memory), method: :delete, class: "secondary" %>

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -1,0 +1,3 @@
+<div id="memories">
+  <%= render @memories %>
+</div>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { memory: @memory, form_legend: "Create memory"} %>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -1,0 +1,1 @@
+<%= render @memory %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,16 @@ Rails.application.routes.draw do
 
   resources :locations
   resources :members
+  resources :memories
   resources :pictures
   resources :teams
   resources :users
   resources :weblinks
 
   resources :current_teams, only: %i[index show create destroy]
+
+  get "/content_visibility/:id/edit", to: "content_visibility#edit", as: "edit_content_visibility"
+  patch "/content_visibility/:id", to: "content_visibility#update", as: "content_visibility"
 
   get "new_search", to: "searches#new", as: "new_search"
   post "search", to: "searches#create", as: "search"

--- a/db/migrate/20240324205926_create_memories.rb
+++ b/db/migrate/20240324205926_create_memories.rb
@@ -1,0 +1,25 @@
+class CreateMemories < ActiveRecord::Migration[7.1]
+  StrongMigrations.disable_check(:add_foreign_key) # as tables are empty
+
+  def change
+    create_enum :content_visibility, %w[draft internal published archived blocked]
+
+    create_table :memories, primary_key: "yid", id: :string do |t|
+      t.text :memo, null: false
+      t.string :team_yid, null: false
+      t.string :location_yid
+      t.string :picture_yid
+      t.string :weblink_yid
+      t.enum :visibility, enum_type: :content_visibility, default: "draft", null: false
+
+      t.timestamps
+    end
+
+    add_index :memories, %i[team_yid]
+
+    add_foreign_key :memories, :locations, column: :location_yid, primary_key: :yid
+    add_foreign_key :memories, :pictures, column: :picture_yid, primary_key: :yid
+    add_foreign_key :memories, :teams, column: :team_yid, primary_key: :yid
+    add_foreign_key :memories, :weblinks, column: :weblink_yid, primary_key: :yid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_23_232748) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_24_205926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "content_visibility", ["draft", "internal", "published", "archived", "blocked"]
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "blob_id", null: false
@@ -148,6 +152,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_23_232748) do
     t.index ["user_yid"], name: "index_members_on_user_yid"
   end
 
+  create_table "memories", primary_key: "yid", id: :string, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "location_yid"
+    t.text "memo", null: false
+    t.string "picture_yid"
+    t.string "team_yid", null: false
+    t.datetime "updated_at", null: false
+    t.enum "visibility", default: "draft", null: false, enum_type: "content_visibility"
+    t.string "weblink_yid"
+    t.index ["team_yid"], name: "index_memories_on_team_yid"
+  end
+
   create_table "pg_search_documents", force: :cascade do |t|
     t.text "content", null: false
     t.datetime "created_at", null: false
@@ -222,6 +238,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_23_232748) do
   add_foreign_key "locations", "teams", column: "team_yid", primary_key: "yid"
   add_foreign_key "members", "teams", column: "team_yid", primary_key: "yid"
   add_foreign_key "members", "users", column: "user_yid", primary_key: "yid"
+  add_foreign_key "memories", "locations", column: "location_yid", primary_key: "yid"
+  add_foreign_key "memories", "pictures", column: "picture_yid", primary_key: "yid"
+  add_foreign_key "memories", "teams", column: "team_yid", primary_key: "yid"
+  add_foreign_key "memories", "weblinks", column: "weblink_yid", primary_key: "yid"
   add_foreign_key "pg_search_documents", "teams", column: "team_yid", primary_key: "yid"
   add_foreign_key "pictures", "teams", column: "team_yid", primary_key: "yid"
   add_foreign_key "weblinks", "teams", column: "team_yid", primary_key: "yid"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,6 +40,8 @@ Location.create_with_history(record: loc, history_params: { team: van, user: and
 weblink = Weblink.new(name: "Yournaling", url: "www.yournaling.com", description: "Your Journaling", team: van)
 Weblink.create_with_history(record: weblink, history_params: { team: van, user: andy })
 
-# TODO: create memory
+memory = Memory.new(team: van, memo: "This is a memory", picture: van_pic, location: loc, weblink: weblink)
+Memory.create_with_history(record: memory, history_params: { team: van, user: andy })
+
 # TODO: create chronicle
 # TODO: create experience


### PR DESCRIPTION
# Making Memories

* Add Memory model - the first content type - which contains
  * a memo text between 4 and 500 characters
  * optionally: a picture insight
  * optionally: a location insight
  * optionally: a weblink insight
* Add content visibility concept
  * every memory starts as `draft`
  * team members of certain roles can advance them to `internal`
  * the `publisher` can advance them to `published`
  * team members of certain roles can advance them to `archived`
  * the visibility status `blocked` will be used by content moderators