### PR TITLE
Switch to using database url

### DIFF
--- a/.github/workflows/ci_push_pull_main.yml
+++ b/.github/workflows/ci_push_pull_main.yml
@@ -36,8 +36,7 @@ jobs:
       RAILS_MAX_THREADS: 5
       OSTYPE: linux
       YOURNALING_DB_HOST: localhost
-      YOURNALING_DB_NAME: yournaling_ci # for db:doctor
-      YOURNALING_DB_NAME_TEST: yournaling_test # for the specs
+      YOURNALING_DB_NAME: yournaling
       YOURNALING_DB_PASSWORD: ci_db_user_password
       YOURNALING_DB_PORT: 5432
       YOURNALING_DB_USERNAME: postgres-ci

--- a/config/app_conf.rb
+++ b/config/app_conf.rb
@@ -83,13 +83,16 @@ class AppConf
   register :yournaling_version, default: env_and_version
 
   # Database setup
-  register :yournaling_db_host, default: "localhost", required: production_env
-  register :yournaling_db_name, default: "yournaling_#{environment}", required: production_env
-  register :yournaling_db_name_test, default: "yournaling_test"
-  register :yournaling_db_password, default: "", required: production_env
-  register :yournaling_db_port, default: 5432, required: production_env
+  register :yournaling_db_host, default: "localhost"
+  register :yournaling_db_name, default: "yournaling", required: production_env
+  register :yournaling_db_password, default: ""
+  register :yournaling_db_port, default: 5432
   register :yournaling_db_timeout_seconds, default: 5, required: production_env
-  register :yournaling_db_username, default: "postgres", required: production_env
+  register :yournaling_db_username, default: "postgres"
+  register :yournaling_db_url,
+    default: "postgres://#{yournaling_db_username}:#{yournaling_db_password}@" \
+             "#{yournaling_db_host}:#{yournaling_db_port}/#{yournaling_db_name}",
+    required: production_env
 
   # determines the size of the DB connection pool and the puma threads
   register :rails_max_threads, default: 6

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,15 +13,15 @@ postgres: &postgres
   <<: *default
   adapter: postgresql
   connect_timeout: <%= AppConf.yournaling_db_timeout_seconds.to_i * 1000 %>
-  database: <%= AppConf.yournaling_db_name %>
   encoding: unicode
-  host: <%= AppConf.yournaling_db_host %>
   migrations_paths: db/migrate
-  password: <%= AppConf.yournaling_db_password %>
-  port: <%= AppConf.yournaling_db_port.to_i %>
   read_timeout: <%= AppConf.yournaling_db_timeout_seconds.to_i * 1000 %>
   reconnect: true
-  username: <%= AppConf.yournaling_db_username %>
+  # database: <%= AppConf.yournaling_db_name %>
+  # host: <%= AppConf.yournaling_db_host %>
+  # password: <%= AppConf.yournaling_db_password %>
+  # port: <%= AppConf.yournaling_db_port.to_i %>
+  # username: <%= AppConf.yournaling_db_username %>
   variables:
     statement_timeout: <%= AppConf.yournaling_db_timeout_seconds.to_i * 1000 %>
 
@@ -48,31 +48,36 @@ queue_config: &queue_config
 development:
   primary:
     <<: *postgres
+    url: <%= "#{AppConf.yournaling_db_url}_development" %>
   cable:
     <<: *cable_config
+    database: <%= "storage/#{AppConf.yournaling_db_name}_development_cable.sqlite3" %>
   cache:
     <<: *cache_config
+    database: <%= "storage/#{AppConf.yournaling_db_name}_development_cache.sqlite3" %>
   queue:
     <<: *queue_config
+    database: <%= "storage/#{AppConf.yournaling_db_name}_development_queue.sqlite3" %>
 
 test:
-  # unfortunately yournaling_db_name_test is necessary, as some `rake db:` commands work against dev & test env
+  # unfortunately _test is necessary, as some `rake db:` commands work against dev & test env
   primary:
     <<: *postgres
-    database: <%= AppConf.yournaling_db_name_test %>
+    url: <%= "#{AppConf.yournaling_db_url}_test" %>
   cable:
     <<: *cable_config
-    database: <%= "storage/#{AppConf.yournaling_db_name_test}_cable.sqlite3" %>
+    database: <%= "storage/#{AppConf.yournaling_db_name}_test_cable.sqlite3" %>
   cache:
     <<: *cache_config
-    database: <%= "storage/#{AppConf.yournaling_db_name_test}_cache.sqlite3" %>
+    database: <%= "storage/#{AppConf.yournaling_db_name}_test_cache.sqlite3" %>
   queue:
     <<: *queue_config
-    database: <%= "storage/#{AppConf.yournaling_db_name_test}_queue.sqlite3" %>
+    database: <%= "storage/#{AppConf.yournaling_db_name}_test_queue.sqlite3" %>
 
 production:
   primary:
     <<: *postgres
+    url: <%= AppConf.yournaling_db_url %>
   cable:
     <<: *cable_config
   cache:


### PR DESCRIPTION
# DATABASE_URL

Passing only one ENV seems to be the common way for production deployments